### PR TITLE
Troca de método de tradução por nomenclatura mais curta

### DIFF
--- a/CspSubmissionPlugin.inc.php
+++ b/CspSubmissionPlugin.inc.php
@@ -255,7 +255,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 				and ($_FILES['uploadedFile']['type'] <> 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') /*docx*/
 				and ($_FILES['uploadedFile']['type'] <> 'application/vnd.oasis.opendocument.text')/*odt*/) {
 					$args[0]->addError('genreId',
-						PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.invalidFormat')
+						__('plugins.generic.CspSubmission.SectionFile.invalidFormat')
 					);
 					break;
 				}
@@ -274,7 +274,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 					$html = new PhpOffice\PhpWord\Writer\HTML($doc);
 					$contagemPalavras = str_word_count(strip_tags($html->getWriterPart('Body')->write()));
 					if ($contagemPalavras > $wordCount) {
-						$phrase = PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.errorWordCount', [
+						$phrase = __('plugins.generic.CspSubmission.SectionFile.errorWordCount', [
 							'sectoin' => $this->article->getData('sectionTitle'),
 							'max'     => $wordCount,
 							'count'   => $contagemPalavras
@@ -287,7 +287,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 				if (($_FILES['uploadedFile']['type'] <> 'image/bmp') /*bmp*/
 				and ($_FILES['uploadedFile']['type'] <> 'image/tiff') /*tiff*/) {
 					$args[0]->addError('genreId',
-						PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.invalidFormat')
+						__('plugins.generic.CspSubmission.SectionFile.invalidFormat')
 					);
 				}
 				break;		
@@ -299,7 +299,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 					and ($_FILES['uploadedFile']['type'] <> 'image/svg+xml')/*svg*/
 					and ($_FILES['uploadedFile']['type'] <> 'image/wmf')/*wmf*/) {
 					$args[0]->addError('genreId',
-						PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.invalidFormat')
+						__('plugins.generic.CspSubmission.SectionFile.invalidFormat')
 					);
 				}
 				break;	
@@ -312,7 +312,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 					and ($_FILES['uploadedFile']['type'] <> 'image/svg+xml')/*svg*/
 					and ($_FILES['uploadedFile']['type'] <> 'image/wmf')/*wmf*/) {
 					$args[0]->addError('genreId',
-						PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.invalidFormat')
+						__('plugins.generic.CspSubmission.SectionFile.invalidFormat')
 					);
 				}
 				break;	
@@ -322,7 +322,7 @@ class CspSubmissionPlugin extends GenericPlugin {
 					and ($_FILES['uploadedFile']['type'] <> 'image/svg+xml')/*svg*/
 					and ($_FILES['uploadedFile']['type'] <> 'image/wmf')/*wmf*/) {
 					$args[0]->addError('genreId',
-						PKPLocale::translate('plugins.generic.CspSubmission.SectionFile.invalidFormat')
+						__('plugins.generic.CspSubmission.SectionFile.invalidFormat')
 					);
 				}
 				break;																


### PR DESCRIPTION
A função `__()`  é um wrapper para o método `PKPLocale::translate`